### PR TITLE
Support comet again

### DIFF
--- a/neuralteleportation/training/training.py
+++ b/neuralteleportation/training/training.py
@@ -128,7 +128,7 @@ def train_epoch(model: nn.Module, metrics: TrainingMetrics, optimizer: Optimizer
         reduced_metrics = {metric: mean(values_by_batch) for metric, values_by_batch in metrics_by_batch.items()}
         config.logger.log_metrics(reduced_metrics, epoch=epoch)
         for metric_name, value in reduced_metrics.items():
-            config.logger.add_scalar(f"train_{metric_name}", value, epoch)
+            config.logger.add_scalar(metric_name, value, epoch)
 
 
 def test(model: nn.Module, dataset: Dataset,

--- a/requirements/computecanada_wheel.txt
+++ b/requirements/computecanada_wheel.txt
@@ -12,5 +12,4 @@ packaging
 seaborn
 torchsummary
 networkx
-tensorboard
-visdom
+comet_ml


### PR DESCRIPTION
Note:

* New command line arg `--enable_comet` for `teleport_training.py`
* The experiment_id (which determines the folder where the results are written on disk) is logged in Comet so the relationship is there.
* do not forget to set your Comet API key